### PR TITLE
Update the apt repo key url, hash, name, and repo url

### DIFF
--- a/FORMULA
+++ b/FORMULA
@@ -1,5 +1,5 @@
 name: salt
-os: Debian, Ubuntu, Raspbian, RedHat, Fedora, CentOS, Oracle, Amazon, Suse, openSUSE, Gentoo, Funtoo, Arch, Manjaro, FreeBSD, OpenBSD, Windows
+os: Debian, Ubuntu, RedHat, Fedora, CentOS, Oracle, Amazon, Suse, openSUSE, Gentoo, Funtoo, Arch, Manjaro, FreeBSD, OpenBSD, Windows
 os_family: Debian, Redhat, Suse, Arch, Gentoo, FreeBSD, Windows
 version: 1.12.0
 release: 1

--- a/salt/osfamilymap.yaml
+++ b/salt/osfamilymap.yaml
@@ -25,9 +25,9 @@
 
 
 Debian:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ osfamily_lower }}/{{ osmajorrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
-  pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main'
+  pkgrepo_keyring: 'https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public'
+  pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
   libgit2: libgit2-22
   pyinotify: python-pyinotify
   gitfs:

--- a/salt/osmap.yaml
+++ b/salt/osmap.yaml
@@ -25,10 +25,10 @@ Amazon:
   key_url: '{{ salt_repo }}/{{ py_ver_repr or 'yum' }}/amazon/2/$basearch/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
 
 Ubuntu:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] {{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/salt-archive-keyring.gpg'
-  pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
-  key_url: '{{ salt_repo }}/{{ py_ver_repr or 'apt' }}/{{ os_lower }}/{{ osrelease }}/amd64/{{ salt_release }}/SALTSTACK-GPG-KEY.pub'
+  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main'
+  pkgrepo_keyring: 'https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public'
+  pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
+  key_url: 'https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public'
   pygit2: python-pygit2
   gitfs:
     pygit2:
@@ -36,10 +36,6 @@ Ubuntu:
       git:
         require_state: false
         install_from_package: Null
-
-Raspbian:
-  pkgrepo: 'deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=armhf] {{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }} {{ oscodename }} main'
-  pkgrepo_keyring: '{{ salt_repo }}/{{ py_ver_repr or 'py3' }}/{{ os_family_lower }}/{{ osmajorrelease }}/armhf/{{ salt_release }}/salt-archive-keyring.gpg'
 
 SmartOS:
   salt_master: salt

--- a/salt/pkgrepo/debian/absent.sls
+++ b/salt/pkgrepo/debian/absent.sls
@@ -10,4 +10,4 @@ salt-pkgrepo-clean-saltstack-debian:
 
 salt-pkgrepo-clean-saltstack-debian-apt-key:
   file.absent:
-    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    - name: /usr/share/keyrings/salt-archive-keyring.pgp

--- a/salt/pkgrepo/debian/clean.sls
+++ b/salt/pkgrepo/debian/clean.sls
@@ -10,4 +10,4 @@ salt-pkgrepo-clean-saltstack-debian:
 
 salt-pkgrepo-clean-saltstack-debian-apt-key:
   file.absent:
-    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    - name: /usr/share/keyrings/salt-archive-keyring.pgp

--- a/salt/pkgrepo/debian/install.sls
+++ b/salt/pkgrepo/debian/install.sls
@@ -4,7 +4,7 @@
 
 salt-pkgrepo-install-saltstack-debian-keyring:
   file.managed:
-    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    - name: /usr/share/keyrings/salt-archive-keyring.pgp
     - source: {{ salt_settings.pkgrepo_keyring }}
     - source_hash: {{ salt_settings.pkgrepo_keyring_hash }}
     - require_in:

--- a/test/integration/default/files/_mapdata/debian-10.yaml
+++ b/test/integration/default/files/_mapdata/debian-10.yaml
@@ -87,10 +87,10 @@ values:
       state: running
     parallel: true
     pin_version: false
-    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64]
-      https://repo.saltproject.io/py3/debian/10/amd64/3003 buster main
-    pkgrepo_keyring: https://repo.saltproject.io/py3/debian/10/amd64/3003/salt-archive-keyring.gpg
-    pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp]
+      https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
+    pkgrepo_keyring: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+    pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
     py_ver: py3
     pyinotify: python-pyinotify
     python_dulwich: python-dulwich

--- a/test/integration/default/files/_mapdata/debian-11.yaml
+++ b/test/integration/default/files/_mapdata/debian-11.yaml
@@ -87,10 +87,10 @@ values:
       state: running
     parallel: true
     pin_version: false
-    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64]
-      https://repo.saltproject.io/py3/debian/11/amd64/3004 bullseye main
-    pkgrepo_keyring: https://repo.saltproject.io/py3/debian/11/amd64/3004/salt-archive-keyring.gpg
-    pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp]
+      https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
+    pkgrepo_keyring: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+    pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
     py_ver: py3
     pyinotify: python-pyinotify
     python_dulwich: python-dulwich

--- a/test/integration/default/files/_mapdata/debian-9.yaml
+++ b/test/integration/default/files/_mapdata/debian-9.yaml
@@ -87,10 +87,10 @@ values:
       state: running
     parallel: true
     pin_version: false
-    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64]
-      https://repo.saltproject.io/py3/debian/9/amd64/3003 stretch main
-    pkgrepo_keyring: https://repo.saltproject.io/py3/debian/9/amd64/3003/salt-archive-keyring.gpg
-    pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp]
+      https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
+    pkgrepo_keyring: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+    pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
     py_ver: py3
     pyinotify: python-pyinotify
     python_dulwich: python-dulwich

--- a/test/integration/default/files/_mapdata/ubuntu-18.yaml
+++ b/test/integration/default/files/_mapdata/ubuntu-18.yaml
@@ -88,10 +88,10 @@ values:
       state: running
     parallel: true
     pin_version: false
-    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64]
-      https://repo.saltproject.io/py3/ubuntu/18.04/amd64/3003 bionic main
-    pkgrepo_keyring: https://repo.saltproject.io/py3/ubuntu/18.04/amd64/3003/salt-archive-keyring.gpg
-    pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp]
+      https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
+    pkgrepo_keyring: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+    pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
     py_ver: py3
     pygit2: python-pygit2
     pyinotify: python-pyinotify

--- a/test/integration/default/files/_mapdata/ubuntu-20.yaml
+++ b/test/integration/default/files/_mapdata/ubuntu-20.yaml
@@ -88,10 +88,10 @@ values:
       state: running
     parallel: true
     pin_version: false
-    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64]
-      https://repo.saltproject.io/py3/ubuntu/20.04/amd64/3004 focal main
-    pkgrepo_keyring: https://repo.saltproject.io/py3/ubuntu/20.04/amd64/3004/salt-archive-keyring.gpg
-    pkgrepo_keyring_hash: sha256=ea38e0cdbd8dc53e1af154a8d711a2a321a69f81188062dc5cde9d54df2b8c47
+    pkgrepo: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp]
+      https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
+    pkgrepo_keyring: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+    pkgrepo_keyring_hash: sha256=36decef986477acb8ba2a1fc4041bcf9f22229ef6c939d0317c9e36a9d142b34
     py_ver: py3
     pygit2: python-pygit2
     pyinotify: python-pyinotify


### PR DESCRIPTION
Now that Broadcom has taken over VMware (and Saltstack), the repo has been updated. Update the apt repo locations for the saltstack repo per

https://saltproject.io/blog/salt-project-package-repo-migration-and-guidance/

Ignoring all the other distros for now.